### PR TITLE
Feature/enable rcon

### DIFF
--- a/ansible/roles/kube-apps/templates/minecraft.j2
+++ b/ansible/roles/kube-apps/templates/minecraft.j2
@@ -67,8 +67,12 @@ spec:
           volumeMounts:
             - name: minecraft-data
               mountPath: /data
+          tty: true
+          stdin: true
           env:
             # Game Configurations
+            - name: DEBUG
+              value: "{{ mc_debug | default("false", true) }}"
             - name: SERVER_NAME
               value: "{{ mc_servername }}"
             - name: SERVER_PORT

--- a/ansible/vars/minikube.yml
+++ b/ansible/vars/minikube.yml
@@ -26,3 +26,17 @@ aenea_lang: es
 aenea_version: develop
 aenea_dbpath: /var/aenea-db
 aenea_loglevel: DEBUG
+
+# Minecraft
+
+mc_heapmem: "2G"
+mc_debug: "true"
+mc_servername: "YGDRASSIL-TST"
+mc_port: "19132"
+mc_moto: "Ygrdassil Minecraft Test Server"
+mc_mode: "creative"
+mc_difficulty: "easy"
+mc_maxplayers: "10"
+mc_ops: "2535438222925699"
+mc_members: "2535438222925699"
+mc_whitelist: "HitchHicker4502"


### PR DESCRIPTION
Altough it's not RCON, this PR allows run the minecraft pod with TTY settings, so it can be attached to run commands over server.
Also, allows activation of debug log level.